### PR TITLE
feat: Add memory usage validation to prevent OOM errors

### DIFF
--- a/src/ocr.rs
+++ b/src/ocr.rs
@@ -593,6 +593,15 @@ fn validate_image_with_format_limits(image_path: &str, config: &OcrConfig) -> Re
                             let estimated_memory_mb = estimate_memory_usage(file_size, &format);
                             info!("Estimated memory usage for {}: {}MB", image_path, estimated_memory_mb);
 
+                            // Check if estimated memory usage exceeds safe limits
+                            let max_memory_mb = 100.0; // 100MB memory limit for OCR processing
+                            if estimated_memory_mb > max_memory_mb {
+                                return Err(anyhow::anyhow!(
+                                    "Estimated memory usage too high: {}MB (maximum allowed: {}MB). File would cause out-of-memory errors.",
+                                    estimated_memory_mb, max_memory_mb
+                                ));
+                            }
+
                             Ok(())
                         }
                         Err(_) => {


### PR DESCRIPTION
- Add memory usage estimation check in validate_image_with_format_limits()
- Reject files that would exceed 100MB memory limit during OCR processing
- Prevent out-of-memory crashes by validating memory requirements upfront
- Log estimated memory usage for monitoring and debugging
- Maintain backward compatibility with existing validation logic